### PR TITLE
Update platform API version to 1.1

### DIFF
--- a/lib/layer/client.rb
+++ b/lib/layer/client.rb
@@ -67,7 +67,6 @@ module Layer
       url = "https://api.layer.com#{url}" unless url.start_with?('https://api.layer.com')
 
       headers = {
-        'Accept' => 'application/vnd.layer+json; version=1.0',
         'Content-Type' => 'application/json',
         'If-None-Match' => SecureRandom.uuid
       }.merge(headers)

--- a/lib/layer/client/platform.rb
+++ b/lib/layer/client/platform.rb
@@ -13,6 +13,7 @@ module Layer
 
       def request(method, url, payload = {}, headers = {})
         url = "https://api.layer.com/apps/#{app_id}#{url}" unless url.start_with?('https://api.layer.com')
+        headers['Accept'] ||= 'application/vnd.layer+json; version=1.1'
         headers['Authorization'] ||= "Bearer #{token}"
 
         super

--- a/lib/layer/client/rest.rb
+++ b/lib/layer/client/rest.rb
@@ -25,6 +25,7 @@ module Layer
 
       def request(method, url, payload = {}, headers = {})
         url = "https://api.layer.com#{url}" unless url.start_with?('https://api.layer.com')
+        headers['Accept'] ||= 'application/vnd.layer+json; version=1.0'
         headers['Authorization'] ||= "Layer session-token=\"#{token}\""
 
         super

--- a/spec/layer/client/platform_spec.rb
+++ b/spec/layer/client/platform_spec.rb
@@ -73,7 +73,7 @@ describe Layer::Client::Platform do
 
         it 'should set the Accept header' do
           expect(RestClient::Request).to have_received(:execute)
-            .with(hash_including(headers: hash_including('Accept' => 'application/vnd.layer+json; version=1.0')))
+            .with(hash_including(headers: hash_including('Accept' => 'application/vnd.layer+json; version=1.1')))
         end
 
         it 'should set the Content-Type header' do


### PR DESCRIPTION
New features might not work unless using the appropriate API version.

* Platform API is at 1.1: https://developer.layer.com/docs/platform/introduction#api-versioning
* Client API is at 1.0: https://developer.layer.com/docs/client/rest#api-versioning
* Webhooks API is at 1.0: https://developer.layer.com/docs/webhooks/requests#request-headers