### PR TITLE
Upgrade rest-client dependency for new Ruby versions

### DIFF
--- a/layer-ruby.gemspec
+++ b/layer-ruby.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rest-client", "~> 1.8"
+  spec.add_dependency "rest-client", "~> 2.0"
   spec.add_dependency "activesupport", "~> 5.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/layer-ruby.gemspec
+++ b/layer-ruby.gemspec
@@ -6,24 +6,24 @@ require 'layer/version'
 Gem::Specification.new do |spec|
   spec.name          = "layer-ruby"
   spec.version       = Layer::VERSION
-  spec.authors       = ["Benedikt Deicke"]
-  spec.email         = ["benedikt@benediktdeicke.com"]
+  spec.authors       = ['Benedikt Deicke']
+  spec.email         = ['benedikt@benediktdeicke.com']
 
   spec.summary       = %q{Ruby bindings for the Layer Platform API}
   spec.description   = %q{Ruby bindings for the Layer Platform API}
-  spec.homepage      = "https://github.com/benedikt/layer-ruby"
-  spec.license       = "MIT"
+  spec.homepage      = 'https://github.com/benedikt/layer-ruby'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "rest-client", "~> 2.0"
-  spec.add_dependency "activesupport", "~> 5.0"
+  spec.add_dependency 'rest-client', '~> 2.0'
+  spec.add_dependency 'activesupport', '> 4.0'
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.3"
-  spec.add_development_dependency "yard", "~> 0.8"
+  spec.add_development_dependency "bundler", '~> 1.10'
+  spec.add_development_dependency "rake", '~> 10.0'
+  spec.add_development_dependency "rspec", '~> 3.3'
+  spec.add_development_dependency "yard", '~> 0.8'
 end

--- a/layer-ruby.gemspec
+++ b/layer-ruby.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rest-client", "~> 1.8"
+  spec.add_dependency "activesupport", "~> 5.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/layer.rb
+++ b/lib/layer.rb
@@ -1,3 +1,6 @@
+require 'active_support'
+require 'active_support/core_ext'
+
 require 'layer/version'
 require 'layer/exceptions'
 require 'layer/client'


### PR DESCRIPTION
Hi @benedikt,

ich bin beim upgraden auf Ruby 2.4 auf diesen Error hier gestossen:
https://github.com/rest-client/rest-client/issues/569

Ich habe daraufhin mal die Dependency im Gem aktualisiert und auch ActiveSupport als Dependency hinzugefügt, damit ``.to_json`` überall verfügbar ist (die Tests schlugen aktuell fehl)